### PR TITLE
set mirador viewer background color

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,11 +15,14 @@
       height: 100%;
       position: fixed;
     }
+    div.mirador-container div.mirador-osd {
+      background-color: #dadad0;
+    }
   </style>
   <link rel="stylesheet" type="text/css" href="build/mirador/css/mirador-combined.css">
   <script src="build/mirador/mirador.min.js"></script>
   <script src="js/MiradorTextLayer.js"></script>
-  
+
   {% if jekyll.environment == 'production' and site.google_analytics %}
   {% include google-analytics.html %}
   {% endif %}


### PR DESCRIPTION
### What does this pull request do?
Sets the background color for Mirador's book and image views to #dadad0.

### What issues does it address?
Closes #35 