### PR TITLE
Render annotation text and connect to toggle menu

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,6 +20,27 @@
     div.mirador-container div.mirador-osd {
       background-color: #dadad0;
     }
+    .mirador-viewer a.mirador-icon-text-layer {
+      background: none;
+      color: #929191;
+      box-sizing: border-box;
+      margin-right:5px;
+      padding-bottom:30px;
+      width: 30px;
+    }
+    .mirador-viewer a.mirador-icon-text-layer:hover {
+      color: black;
+    }
+    .mirador-viewer a.mirador-icon-text-layer.selected {
+      color: black;
+    }
+    a.mirador-icon-text-layer [class^="icon-"] {
+      display:block;
+      position:absolute;
+    }
+    .mirador-container .text-layer-list {
+      right: 1em;
+    }
   </style>
   <link rel="stylesheet" type="text/css" href="build/mirador/css/mirador-combined.css">
   <script src="build/mirador/mirador.min.js"></script>

--- a/js/MiradorTextLayer.js
+++ b/js/MiradorTextLayer.js
@@ -4,14 +4,25 @@ var MiradorTextLayer = {
     locales: {
         en: {
             translation: {
-                'button-tooltip': 'Show Text Layer'
+                'button-tooltip': 'Show Text Layer',
+                'text-layer-none': 'None',
+                'text-layer-en': 'English',
+                'text-layer-fr': 'French',
+                'text-layer-fro': 'Original'
             }
         }
     },
 
     template: Mirador.Handlebars.compile([
-        '<a href="javascript:;" class="mirador-btn mirador-icon-disable-zoom contained-tooltip" title="{{t "button-tooltip"}}">',
+        '<a href="javascript:;" class="mirador-btn mirador-icon-text-layer" title="{{t "button-tooltip"}}">',
             '<i class="fa fa-align-left fa-lg fa-fw"></i>',
+            '<i class="fa fa-caret-down"></i>',
+            '<ul class="dropdown text-layer-list">',
+              '<li class="text-layer-none"><i class="fa fa-ban fa-lg fa-fw"></i> {{t "text-layer-none"}}</li>',
+              '<li class="text-layer-en"><i class="fa fa-font fa-lg fa-fw"></i> {{t "text-layer-en"}}</li>',
+              '<li class="text-layer-fr"><i class="fa fa-font fa-lg fa-fw"></i> {{t "text-layer-fr"}}</li>',
+              '<li class="text-layer-fro"><i class="fa fa-font fa-lg fa-fw"></i> {{t "text-layer-fro"}}</li>',
+            '</ul>',
         '</a>'
     ].join('')),
 
@@ -40,6 +51,12 @@ var MiradorTextLayer = {
 
             /* 1. Override methods and register (and document!) new ones. */
 
+            $.Window.prototype.textLayerKeys = [
+              'en',
+              'fr',
+              'fro'
+            ];
+
             $.Window.prototype.listenForActions = function() {
                 var _this = this;
                 listenForActions.apply(this, arguments);
@@ -47,7 +64,49 @@ var MiradorTextLayer = {
                 this.eventEmitter.subscribe('focusUpdated' + this.id, function(event, focusState) {
                     // triggered when toggling viewing states or changing the current canvas
                     // a new OSD will be created, so just de-select the button
-                    _this.element.find('.mirador-icon-disable-zoom').removeClass('selected');
+                    _this.element.find('.mirador-icon-text-layer').removeClass('selected');
+                });
+
+                var annotationTextPad = 20,
+                  defaultLayer = 'en',
+                  backdropColor = '#E6D9B7',
+                  backdropOpacity = 0.7;
+                var timeout;
+                this.currentTextLayer = defaultLayer;
+                this.eventEmitter.subscribe('annotationsRendered.' + _this.id, function() {
+                  if (timeout) clearTimeout(timeout);
+                  timeout = setTimeout(function() {
+                    var items = _this.focusModules.ImageView.annotationsLayer.drawTool.annotationsToShapesMap;
+                    if (items) {
+                      for (key in items) {
+                        var item = items[key][0];
+                        if (item.data && item.data.annotation && item.data.annotation.resource) {
+                          var resource = item.data.annotation.resource;
+                          var bounds = item.bounds;
+                          if (resource.length > 0) resource = resource[0];
+                          if (resource.chars && bounds) {
+                            var r = new paper.Path.Rectangle({
+                              point: [bounds.x, bounds.y],
+                              size: [bounds.width, bounds.height],
+                              fillColor: backdropColor,
+                              opacity: backdropOpacity,
+                              name: item.name + '_' + resource.language + '_bgrect',
+                              visible: resource.language == _this.currentTextLayer
+                            });
+                            var t = new paper.PointText();
+                            t.point = new paper.Point(bounds.x + annotationTextPad, bounds.y + bounds.height - annotationTextPad);
+                            t.content = resource.chars;
+                            t.fontSize = (bounds.height - 2 * annotationTextPad) + "px";
+                            t.name = item.name + '_' + resource.language + '_text';
+                            t.visible = (resource.language == _this.currentTextLayer);
+                            if (t.bounds.width + annotationTextPad > r.bounds.width) r.bounds.width = t.bounds.width + annotationTextPad * 2.0;
+                            item.visible = false;
+                          }
+                        }
+                      }
+                    }
+                    paper.view.draw();
+                  }, 300);
                 });
             };
 
@@ -57,20 +116,60 @@ var MiradorTextLayer = {
 
                 // add button (the compiled template) to the DOM
                 this.element.find('.window-manifest-navigation').prepend(self.template());
-                // add click handler for the new button
-                this.element.find('.mirador-icon-disable-zoom').on('click', function(event) {
-                    _this.showTextLayer(this, !_this.textLayerShown);
+
+                _this.bindTextLayerNavigation();
+            };
+
+            $.Window.prototype.bindTextLayerNavigation = function() {
+                var _this = this;
+
+                this.element.find('.mirador-icon-text-layer').on('mouseenter',
+                  function() {
+                    _this.element.find('.text-layer-list').stop().slideFadeToggle(300);
+                  }).on('mouseleave',
+                  function() {
+                    _this.element.find('.text-layer-list').stop().slideFadeToggle(300);
+                  });
+
+                this.element.find('.text-layer-none').on('click', function() {
+                  var view = _this.focusModules.ImageView;
+                  if (view.hud.annoState.current === 'none') {
+                    view.hud.annoState.startup(this);
+                  }
+                  if (view.hud.annoState.current !== 'off') {
+                    view.forceShowControls = false;
+                    view.hud.annoState.displayOff(this);
+                    view.annotationState = 'off';
+                  }
+                  _this.currentTextLayer = 'none';
+                });
+
+                _this.textLayerKeys.forEach(function(layerType) {
+                  _this.bindTextLayerClick(layerType);
                 });
             };
 
-            /*
-             * Mirador.Window.prototype.showTextLayer
-             *
-             * Shows and hides the textLayer
-             */
-            $.Window.prototype.showTextLayer = function() {
-                console.log("showed the text layer");
+            $.Window.prototype.bindTextLayerClick = function(layerType) {
+              var _this = this;
+              this.element.find('.text-layer-' + layerType).on('click', function() {
+                var view = _this.focusModules.ImageView;
+                if (view.hud.annoState.current === 'none') {
+                  view.hud.annoState.startup(this);
+                }
+                if (view.hud.annoState.current === 'off') {
+                  view.hud.annoState.displayOn(this);
+                  view.annotationState = 'on';
+                }
+                paper.project.getItems({name: new RegExp('_(' + _this.textLayerKeys.join('|') + ')_')}).forEach(function(item) {
+                  item.visible = false;
+                });
+                paper.project.getItems({name: new RegExp('_' + layerType + '_')}).forEach(function(item) {
+                  item.visible = true;
+                });
+                _this.currentTextLayer = layerType;
+              });
             };
+
 
             /* 2. Override the constructor. */
 
@@ -94,7 +193,7 @@ var MiradorTextLayer = {
                 var constructor = $[viewType],
                     prototype = $[viewType].prototype,
                     listenForActions = $[viewType].prototype.listenForActions;
-            
+
                 /* 1. */
 
                 $[viewType].prototype.listenForActions = function() {

--- a/manifest.json
+++ b/manifest.json
@@ -3,4571 +3,5417 @@
   "@id": "http://fauvel.archivengine.com/manifest.json",
   "@type": "sc:Manifest",
   "label": "Roman de Fauvel",
-  "metadata": [],
+  "metadata": [
+
+  ],
   "description": "A digital facsimile edition of the Roman de Fauvel",
   "license": "https://creativecommons.org/licenses/by/3.0/",
   "attribution": "http://gallica.bnf.fr/ark:/12148/btv1b8454675g/",
-  "sequences": [{
-    "@context": "http://iiif.io/api/presentation/2/context.json",
-    "@id": "http://fauvel.archivengine.com/sequence/normal",
-    "@type": "sc:Sequence",
-    "label": [{
-      "@value": "Normal Sequence",
-      "@language": "en"
-    }],
-    "canvases": [{
-        "@id": "http://fauvel.archivengine.com/canvas/Br",
-        "@type": "sc:Canvas",
-        "label": "Folio Br",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/Br-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/11.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/11.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/Br"
-        }]
-      },
-			{
-        "@id": "http://fauvel.archivengine.com/canvas/Bv",
-        "@type": "sc:Canvas",
-        "label": "Folio Bv",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/Bv-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/12.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/12.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/Br"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/1r",
-        "@type": "sc:Canvas",
-        "label": "Folio 1r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/1r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/13.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/13.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/1r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/1r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/1v",
-        "@type": "sc:Canvas",
-        "label": "Folio 1v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/1v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/14.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/14.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/1v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/1v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      }, {
-        "@id": "http://fauvel.archivengine.com/canvas/2r",
-        "@type": "sc:Canvas",
-        "label": "Folio 2r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/2r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/15.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/15.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/2r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/2r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/2v",
-        "@type": "sc:Canvas",
-        "label": "Folio 2v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/2v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/16.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/16.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/2v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/2v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/3r",
-        "@type": "sc:Canvas",
-        "label": "Folio 3r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/3r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/17.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/17.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/3r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/3r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/3v",
-        "@type": "sc:Canvas",
-        "label": "Folio 3v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/3v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/18.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/18.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/3v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/3v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/4r",
-        "@type": "sc:Canvas",
-        "label": "Folio 4r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/4r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/19.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/19.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/4r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/4r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/4v",
-        "@type": "sc:Canvas",
-        "label": "Folio 4v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/4v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/20.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/20.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/4v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/4v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/5r",
-        "@type": "sc:Canvas",
-        "label": "Folio 5r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/5r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/21.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/21.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/5r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/5r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/5v",
-        "@type": "sc:Canvas",
-        "label": "Folio 5v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/5v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/22.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/22.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/5v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/5v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/6r",
-        "@type": "sc:Canvas",
-        "label": "Folio 6r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/6r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/23.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/23.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/6r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/6r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/6v",
-        "@type": "sc:Canvas",
-        "label": "Folio 6v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/6v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/24.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/24.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/6v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/6v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/7r",
-        "@type": "sc:Canvas",
-        "label": "Folio 7r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/7r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/25.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/25.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/7r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/7r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/7v",
-        "@type": "sc:Canvas",
-        "label": "Folio 7v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/7v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/26.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/26.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/7v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/7v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/8r",
-        "@type": "sc:Canvas",
-        "label": "Folio 8r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/8r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/27.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/27.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/8r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/8r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/8v",
-        "@type": "sc:Canvas",
-        "label": "Folio 8v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/8v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/28.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/28.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/8v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/8v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/9r",
-        "@type": "sc:Canvas",
-        "label": "Folio 9r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/9r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/29.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/29.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/9r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/9r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/9v",
-        "@type": "sc:Canvas",
-        "label": "Folio 9v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/9v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/30.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/30.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/9v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/9v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/10r",
-        "@type": "sc:Canvas",
-        "label": "Folio 10r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/10r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/31.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/31.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/10r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/10r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/10v",
-        "@type": "sc:Canvas",
-        "label": "Folio 10v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/10v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/32.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/32.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/10v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/10v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/11r",
-        "@type": "sc:Canvas",
-        "label": "Folio 33",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://eb965a77-11b0-4de6-a5ca-efcebc2a7c1b",
-          "@type": "oa:Annotation",
-          "motivation": "sc:painting",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/33.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/33.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/10v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/10v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/11v",
-        "@type": "sc:Canvas",
-        "label": "Folio 11v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/11v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/34.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/34.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/11v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/11v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/12r",
-        "@type": "sc:Canvas",
-        "label": "Folio 12r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/12r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/35.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/35.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/12r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/12r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/12v",
-        "@type": "sc:Canvas",
-        "label": "Folio 12v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/12v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/36.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/36.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/12v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/12v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/13r",
-        "@type": "sc:Canvas",
-        "label": "Folio 13r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/13r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/37.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/37.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/13r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/13r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/13v",
-        "@type": "sc:Canvas",
-        "label": "Folio 13v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/13v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/38.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/38.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/13v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/13v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/14r",
-        "@type": "sc:Canvas",
-        "label": "Folio 14r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/14r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/39.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/39.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/13r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/13r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/14v",
-        "@type": "sc:Canvas",
-        "label": "Folio 14v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/14v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/40.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/40.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/14v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/14v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/15r",
-        "@type": "sc:Canvas",
-        "label": "Folio 15r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/15r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/41.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/41.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/15r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/15r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/15v",
-        "@type": "sc:Canvas",
-        "label": "Folio 15v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/15v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/42.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/42.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/15v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/15v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/16r",
-        "@type": "sc:Canvas",
-        "label": "Folio 16r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/16r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/43.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/43.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/16r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/16r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/16v",
-        "@type": "sc:Canvas",
-        "label": "Folio 16v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/16v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/44.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/44.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/16v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/16v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/17r",
-        "@type": "sc:Canvas",
-        "label": "Folio 17r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/17r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/45.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/45.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/17r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/17r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/17v",
-        "@type": "sc:Canvas",
-        "label": "Folio 17v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/17v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/46.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/46.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/17v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/17v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/18r",
-        "@type": "sc:Canvas",
-        "label": "Folio 18r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/18r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/47.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/47.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/18r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/18r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/18v",
-        "@type": "sc:Canvas",
-        "label": "Folio 18v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/18v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/48.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/48.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/18v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/18v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/19r",
-        "@type": "sc:Canvas",
-        "label": "Folio 19r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/19r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/49.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/49.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/19r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/19r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/19v",
-        "@type": "sc:Canvas",
-        "label": "Folio 19v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/19v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/50.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/50.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/19v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/19v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/20r",
-        "@type": "sc:Canvas",
-        "label": "Folio 20r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/20r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/51.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/51.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/20r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/20r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/20v",
-        "@type": "sc:Canvas",
-        "label": "Folio 20v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/20v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/52.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/52.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/20v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/20v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/21r",
-        "@type": "sc:Canvas",
-        "label": "Folio 21r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/21r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/53.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/53.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/21r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/21r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/21v",
-        "@type": "sc:Canvas",
-        "label": "Folio 21v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/21v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/54.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/54.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/21v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/21v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/22r",
-        "@type": "sc:Canvas",
-        "label": "Folio 22r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/22r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/55.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/55.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/22r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/22r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/22v",
-        "@type": "sc:Canvas",
-        "label": "Folio 22v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/22v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/56.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/56.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/22v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/22v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/23r",
-        "@type": "sc:Canvas",
-        "label": "Folio 23r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/23r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/57.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/57.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/23r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/23r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/23v",
-        "@type": "sc:Canvas",
-        "label": "Folio 23v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/23v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/58.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/58.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/23v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/23v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/24r",
-        "@type": "sc:Canvas",
-        "label": "Folio 24r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/24r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/59.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/59.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/24r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/24r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/24v",
-        "@type": "sc:Canvas",
-        "label": "Folio 24v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/24v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/60.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/60.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/24v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/24v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/25r",
-        "@type": "sc:Canvas",
-        "label": "Folio 25r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/25r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/61.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/61.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/25r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/25r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/25v",
-        "@type": "sc:Canvas",
-        "label": "Folio 25v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/25v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/62.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/62.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/25v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/25v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/26r",
-        "@type": "sc:Canvas",
-        "label": "Folio 26r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/26r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/63.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/63.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/26r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/26r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/26v",
-        "@type": "sc:Canvas",
-        "label": "Folio 26v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/26v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/64.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/64.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/26v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/26v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/27r",
-        "@type": "sc:Canvas",
-        "label": "Folio 27r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/27r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/65.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/65.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/27r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/27r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/27v",
-        "@type": "sc:Canvas",
-        "label": "Folio 27v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/27v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/66.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/66.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/27v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/27v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/28r",
-        "@type": "sc:Canvas",
-        "label": "Folio 28r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/28r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/67.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/67.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/28r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/28r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/28v",
-        "@type": "sc:Canvas",
-        "label": "Folio 28v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/28v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/68.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/68.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/28v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/28v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/28bis-r",
-        "@type": "sc:Canvas",
-        "label": "Folio 28bis-r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://65d989fb-b00d-4a62-8cc8-7aa56c2c0da5",
-          "@type": "oa:Annotation",
-          "motivation": "sc:painting",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/69.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/69.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/28bis-r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/28bis-r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/28bis-v",
-        "@type": "sc:Canvas",
-        "label": "Folio 28bis-v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://3acffcbd-67aa-4a4d-b0d4-7dab122ec99e",
-          "@type": "oa:Annotation",
-          "motivation": "sc:painting",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/70.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/70.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/28bis-v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/28bis-v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/28ter-r",
-        "@type": "sc:Canvas",
-        "label": "Folio 28ter-r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://ab3ffd2b-3473-4263-b252-b0a8899291fb",
-          "@type": "oa:Annotation",
-          "motivation": "sc:painting",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/71.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/71.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/28ter-r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/28ter-r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/28ter-v",
-        "@type": "sc:Canvas",
-        "label": "Folio 28ter-v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://7702803d-4c5f-476d-9aaa-79ba3df1b2d9",
-          "@type": "oa:Annotation",
-          "motivation": "sc:painting",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/72.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/72.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/28ter-v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/28ter-v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/29r",
-        "@type": "sc:Canvas",
-        "label": "Folio 29r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/29r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/73.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/73.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/29r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/29r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/29v",
-        "@type": "sc:Canvas",
-        "label": "Folio 29v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/29v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/74.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/74.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/29v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/29v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/30r",
-        "@type": "sc:Canvas",
-        "label": "Folio 30r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/30r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/75.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/75.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/30r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/30r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/30v",
-        "@type": "sc:Canvas",
-        "label": "Folio 30v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/30v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/76.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/76.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/30v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/30v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/31r",
-        "@type": "sc:Canvas",
-        "label": "Folio 31r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/31r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/77.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/77.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/31r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/31r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/31v",
-        "@type": "sc:Canvas",
-        "label": "Folio 31v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/31v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/78.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/78.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/31v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/31v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/32r",
-        "@type": "sc:Canvas",
-        "label": "Folio 32r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/32r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/79.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/79.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/32r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/32r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/32v",
-        "@type": "sc:Canvas",
-        "label": "Folio 32v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/32v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/80.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/80.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/32v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/32v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/33r",
-        "@type": "sc:Canvas",
-        "label": "Folio 33r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/33r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/81.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/81.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/33r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/33r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/33v",
-        "@type": "sc:Canvas",
-        "label": "Folio 33v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/33v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/82.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/82.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/33v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/33v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/34r",
-        "@type": "sc:Canvas",
-        "label": "Folio 34r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/34r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/83.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/83.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/34r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/34r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/34v",
-        "@type": "sc:Canvas",
-        "label": "Folio 34v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/34v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/84.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/84.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/34v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/34v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/35r",
-        "@type": "sc:Canvas",
-        "label": "Folio 35r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/35r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/85.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/85.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/35r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/35r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/35v",
-        "@type": "sc:Canvas",
-        "label": "Folio 35v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/35v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/86.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/86.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/35v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/35v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/36r",
-        "@type": "sc:Canvas",
-        "label": "Folio 36r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/36r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/87.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/87.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/36r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/36r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/36v",
-        "@type": "sc:Canvas",
-        "label": "Folio 36v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/36v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/88.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/88.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/36v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/36v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/37r",
-        "@type": "sc:Canvas",
-        "label": "Folio 37r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/37r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/89.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/89.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/37r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/37r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/37v",
-        "@type": "sc:Canvas",
-        "label": "Folio 37v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/37v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/90.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/90.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/37v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/37v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/38r",
-        "@type": "sc:Canvas",
-        "label": "Folio 38r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/38r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/91.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/91.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/38r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/38r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/38v",
-        "@type": "sc:Canvas",
-        "label": "Folio 38v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/38v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/92.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/92.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/38v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/38v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/39r",
-        "@type": "sc:Canvas",
-        "label": "Folio 39r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/39r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/93.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/93.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/39r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/39r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/39v",
-        "@type": "sc:Canvas",
-        "label": "Folio 39v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/39v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/94.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/94.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/39v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/39v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/40r",
-        "@type": "sc:Canvas",
-        "label": "Folio 40r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/40r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/95.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/95.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/40r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/40r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/40v",
-        "@type": "sc:Canvas",
-        "label": "Folio 40v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/40v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/96.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/96.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/40v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/40v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/41r",
-        "@type": "sc:Canvas",
-        "label": "Folio 41r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/41r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/97.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/97.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/41r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/41r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/41v",
-        "@type": "sc:Canvas",
-        "label": "Folio 41v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/41v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/98.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/98.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/41v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/41v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/42r",
-        "@type": "sc:Canvas",
-        "label": "Folio 42r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/42r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/99.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/99.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/42r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/42r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/42v",
-        "@type": "sc:Canvas",
-        "label": "Folio 42v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/42v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/100.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/100.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/42v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/42v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/43r",
-        "@type": "sc:Canvas",
-        "label": "Folio 43r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/43r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/101.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/101.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/43r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/43r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/43v",
-        "@type": "sc:Canvas",
-        "label": "Folio 43v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/43v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/102.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/102.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/43v"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/43v.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/44r",
-        "@type": "sc:Canvas",
-        "label": "Folio 44r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/44r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/103.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/103.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/44r"
-        }],
-        "otherContent": [{
-          "@id": "http://fauvel.archivengine.com/list/en/44r.json",
-          "@type": "sc:AnnotationList"
-        }]
-      },
-      {
-        "@id": "http://fauvel.archivengine.com/canvas/44v",
-        "@type": "sc:Canvas",
-        "label": "Folio 44v",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/44v-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/104.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/104.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/44v"
-        }]
-      }, {
-        "@id": "http://fauvel.archivengine.com/canvas/45r",
-        "@type": "sc:Canvas",
-        "label": "Folio 45r",
-        "height": 7350,
-        "width": 5250,
-        "images": [{
-          "@context": "http://iiif.io/api/presentation/2/context.json",
-          "@id": "http://fauvel.archivengine.com/annotation/45r-image",
-          "resource": {
-            "@id": "https://iip.textlab.org/?IIIF=fauvel/105.tiff/full/full/0/default.jpg",
-            "@type": "dctypes:Image",
-            "format": "image/jpeg",
-            "service": {
-              "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://iip.textlab.org/?IIIF=fauvel/105.tiff",
-              "profile": [
-                "http://iiif.io/api/image/2/level1.json", {
-                  "formats": [
-                    "jpg"
-                  ],
-                  "qualities": [
-                    "native",
-                    "color",
-                    "gray"
-                  ],
-                  "supports": [
-                    "regionByPct",
-                    "sizeByForcedWh",
-                    "sizeByWh",
-                    "sizeAboveFull",
-                    "rotationBy90s",
-                    "mirroring",
-                    "gray"
-                  ]
-                }
-              ]
-            },
-            "height": 7350,
-            "width": 5250
-          },
-          "on": "http://fauvel.archivengine.com/canvas/45r"
-        }]
-      }
-    ]
-  }],
-  "structures": []
+  "sequences": [
+    {
+      "@context": "http://iiif.io/api/presentation/2/context.json",
+      "@id": "http://fauvel.archivengine.com/sequence/normal",
+      "@type": "sc:Sequence",
+      "label": [
+        {
+          "@value": "Normal Sequence",
+          "@language": "en"
+        }
+      ],
+      "canvases": [
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/Br",
+          "@type": "sc:Canvas",
+          "label": "Folio Br",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/Br-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/11.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/11.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/Br"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/Bv",
+          "@type": "sc:Canvas",
+          "label": "Folio Bv",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/Bv-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/12.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/12.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/Br"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/1r",
+          "@type": "sc:Canvas",
+          "label": "Folio 1r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/1r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/13.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/13.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/1r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/1r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/1r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/1r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/1v",
+          "@type": "sc:Canvas",
+          "label": "Folio 1v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/1v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/14.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/14.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/1v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/1v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/1v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/2r",
+          "@type": "sc:Canvas",
+          "label": "Folio 2r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/2r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/15.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/15.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/2r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/2r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/2r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/2v",
+          "@type": "sc:Canvas",
+          "label": "Folio 2v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/2v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/16.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/16.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/2v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/2v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/2v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/3r",
+          "@type": "sc:Canvas",
+          "label": "Folio 3r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/3r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/17.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/17.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/3r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/3r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/3r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/3v",
+          "@type": "sc:Canvas",
+          "label": "Folio 3v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/3v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/18.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/18.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/3v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/3v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/3v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/4r",
+          "@type": "sc:Canvas",
+          "label": "Folio 4r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/4r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/19.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/19.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/4r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/4r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/4r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/4v",
+          "@type": "sc:Canvas",
+          "label": "Folio 4v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/4v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/20.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/20.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/4v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/4v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/4v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/5r",
+          "@type": "sc:Canvas",
+          "label": "Folio 5r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/5r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/21.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/21.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/5r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/5r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/5r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/5v",
+          "@type": "sc:Canvas",
+          "label": "Folio 5v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/5v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/22.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/22.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/5v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/5v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/5v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/6r",
+          "@type": "sc:Canvas",
+          "label": "Folio 6r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/6r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/23.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/23.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/6r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/6r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/6r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/6v",
+          "@type": "sc:Canvas",
+          "label": "Folio 6v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/6v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/24.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/24.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/6v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/6v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/6v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/7r",
+          "@type": "sc:Canvas",
+          "label": "Folio 7r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/7r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/25.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/25.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/7r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/7r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/7r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/7v",
+          "@type": "sc:Canvas",
+          "label": "Folio 7v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/7v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/26.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/26.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/7v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/7v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/7v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/8r",
+          "@type": "sc:Canvas",
+          "label": "Folio 8r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/8r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/27.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/27.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/8r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/8r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/8r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/8v",
+          "@type": "sc:Canvas",
+          "label": "Folio 8v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/8v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/28.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/28.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/8v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/8v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/8v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/9r",
+          "@type": "sc:Canvas",
+          "label": "Folio 9r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/9r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/29.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/29.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/9r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/9r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/9r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/9v",
+          "@type": "sc:Canvas",
+          "label": "Folio 9v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/9v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/30.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/30.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/9v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/9v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/9v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/10r",
+          "@type": "sc:Canvas",
+          "label": "Folio 10r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/10r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/31.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/31.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/10r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/10r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/10r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/10v",
+          "@type": "sc:Canvas",
+          "label": "Folio 10v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/10v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/32.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/32.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/10v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/10v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/10v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/11r",
+          "@type": "sc:Canvas",
+          "label": "Folio 33",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://eb965a77-11b0-4de6-a5ca-efcebc2a7c1b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/33.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/33.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/10v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/10v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/10v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/11v",
+          "@type": "sc:Canvas",
+          "label": "Folio 11v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/11v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/34.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/34.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/11v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/11v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/11v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/12r",
+          "@type": "sc:Canvas",
+          "label": "Folio 12r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/12r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/35.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/35.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/12r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/12r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/12r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/12v",
+          "@type": "sc:Canvas",
+          "label": "Folio 12v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/12v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/36.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/36.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/12v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/12v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/12v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/13r",
+          "@type": "sc:Canvas",
+          "label": "Folio 13r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/13r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/37.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/37.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/13r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/13r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/13r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/13v",
+          "@type": "sc:Canvas",
+          "label": "Folio 13v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/13v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/38.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/38.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/13v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/13v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/13v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/14r",
+          "@type": "sc:Canvas",
+          "label": "Folio 14r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/14r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/39.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/39.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/13r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/13r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/13r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/14v",
+          "@type": "sc:Canvas",
+          "label": "Folio 14v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/14v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/40.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/40.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/14v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/14v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/14v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/15r",
+          "@type": "sc:Canvas",
+          "label": "Folio 15r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/15r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/41.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/41.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/15r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/15r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/15r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/15v",
+          "@type": "sc:Canvas",
+          "label": "Folio 15v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/15v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/42.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/42.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/15v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/15v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/15v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/16r",
+          "@type": "sc:Canvas",
+          "label": "Folio 16r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/16r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/43.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/43.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/16r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/16r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/16r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/16v",
+          "@type": "sc:Canvas",
+          "label": "Folio 16v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/16v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/44.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/44.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/16v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/16v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/16v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/17r",
+          "@type": "sc:Canvas",
+          "label": "Folio 17r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/17r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/45.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/45.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/17r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/17r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/17r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/17v",
+          "@type": "sc:Canvas",
+          "label": "Folio 17v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/17v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/46.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/46.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/17v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/17v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/17v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/18r",
+          "@type": "sc:Canvas",
+          "label": "Folio 18r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/18r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/47.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/47.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/18r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/18r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/18r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/18v",
+          "@type": "sc:Canvas",
+          "label": "Folio 18v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/18v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/48.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/48.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/18v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/18v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/18v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/19r",
+          "@type": "sc:Canvas",
+          "label": "Folio 19r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/19r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/49.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/49.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/19r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/19r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/19r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/19v",
+          "@type": "sc:Canvas",
+          "label": "Folio 19v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/19v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/50.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/50.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/19v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/19v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/19v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/20r",
+          "@type": "sc:Canvas",
+          "label": "Folio 20r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/20r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/51.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/51.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/20r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/20r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/20r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/20v",
+          "@type": "sc:Canvas",
+          "label": "Folio 20v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/20v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/52.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/52.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/20v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/20v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/20v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/21r",
+          "@type": "sc:Canvas",
+          "label": "Folio 21r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/21r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/53.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/53.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/21r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/21r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/21r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/21v",
+          "@type": "sc:Canvas",
+          "label": "Folio 21v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/21v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/54.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/54.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/21v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/21v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/21v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/22r",
+          "@type": "sc:Canvas",
+          "label": "Folio 22r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/22r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/55.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/55.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/22r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/22r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/22r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/22v",
+          "@type": "sc:Canvas",
+          "label": "Folio 22v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/22v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/56.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/56.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/22v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/22v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/22v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/23r",
+          "@type": "sc:Canvas",
+          "label": "Folio 23r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/23r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/57.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/57.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/23r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/23r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/23r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/23v",
+          "@type": "sc:Canvas",
+          "label": "Folio 23v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/23v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/58.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/58.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/23v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/23v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/23v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/24r",
+          "@type": "sc:Canvas",
+          "label": "Folio 24r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/24r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/59.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/59.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/24r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/24r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/24r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/24v",
+          "@type": "sc:Canvas",
+          "label": "Folio 24v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/24v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/60.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/60.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/24v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/24v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/24v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/25r",
+          "@type": "sc:Canvas",
+          "label": "Folio 25r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/25r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/61.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/61.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/25r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/25r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/25r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/25v",
+          "@type": "sc:Canvas",
+          "label": "Folio 25v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/25v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/62.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/62.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/25v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/25v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/25v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/26r",
+          "@type": "sc:Canvas",
+          "label": "Folio 26r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/26r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/63.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/63.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/26r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/26r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/26r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/26v",
+          "@type": "sc:Canvas",
+          "label": "Folio 26v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/26v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/64.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/64.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/26v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/26v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/26v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/27r",
+          "@type": "sc:Canvas",
+          "label": "Folio 27r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/27r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/65.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/65.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/27r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/27r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/27r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/27v",
+          "@type": "sc:Canvas",
+          "label": "Folio 27v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/27v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/66.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/66.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/27v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/27v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/27v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/28r",
+          "@type": "sc:Canvas",
+          "label": "Folio 28r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/28r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/67.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/67.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/28r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/28r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/28r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/28v",
+          "@type": "sc:Canvas",
+          "label": "Folio 28v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/28v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/68.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/68.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/28v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/28v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/28v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/28bis-r",
+          "@type": "sc:Canvas",
+          "label": "Folio 28bis-r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://65d989fb-b00d-4a62-8cc8-7aa56c2c0da5",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/69.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/69.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/28bis-r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/28bis-r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/28bis-r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/28bis-v",
+          "@type": "sc:Canvas",
+          "label": "Folio 28bis-v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://3acffcbd-67aa-4a4d-b0d4-7dab122ec99e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/70.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/70.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/28bis-v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/28bis-v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/28bis-v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/28ter-r",
+          "@type": "sc:Canvas",
+          "label": "Folio 28ter-r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://ab3ffd2b-3473-4263-b252-b0a8899291fb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/71.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/71.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/28ter-r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/28ter-r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/28ter-r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/28ter-v",
+          "@type": "sc:Canvas",
+          "label": "Folio 28ter-v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://7702803d-4c5f-476d-9aaa-79ba3df1b2d9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/72.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/72.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/28ter-v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/28ter-v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/28ter-v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/29r",
+          "@type": "sc:Canvas",
+          "label": "Folio 29r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/29r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/73.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/73.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/29r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/29r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/29r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/29v",
+          "@type": "sc:Canvas",
+          "label": "Folio 29v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/29v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/74.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/74.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/29v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/29v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/29v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/30r",
+          "@type": "sc:Canvas",
+          "label": "Folio 30r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/30r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/75.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/75.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/30r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/30r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/30r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/30v",
+          "@type": "sc:Canvas",
+          "label": "Folio 30v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/30v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/76.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/76.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/30v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/30v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/30v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/31r",
+          "@type": "sc:Canvas",
+          "label": "Folio 31r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/31r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/77.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/77.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/31r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/31r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/31r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/31v",
+          "@type": "sc:Canvas",
+          "label": "Folio 31v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/31v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/78.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/78.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/31v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/31v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/31v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/32r",
+          "@type": "sc:Canvas",
+          "label": "Folio 32r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/32r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/79.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/79.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/32r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/32r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/32r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/32v",
+          "@type": "sc:Canvas",
+          "label": "Folio 32v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/32v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/80.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/80.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/32v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/32v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/32v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/33r",
+          "@type": "sc:Canvas",
+          "label": "Folio 33r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/33r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/81.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/81.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/33r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/33r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/33r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/33v",
+          "@type": "sc:Canvas",
+          "label": "Folio 33v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/33v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/82.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/82.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/33v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/33v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/33v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/34r",
+          "@type": "sc:Canvas",
+          "label": "Folio 34r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/34r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/83.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/83.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/34r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/34r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/34r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/34v",
+          "@type": "sc:Canvas",
+          "label": "Folio 34v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/34v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/84.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/84.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/34v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/34v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/34v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/35r",
+          "@type": "sc:Canvas",
+          "label": "Folio 35r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/35r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/85.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/85.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/35r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/35r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/35r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/35v",
+          "@type": "sc:Canvas",
+          "label": "Folio 35v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/35v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/86.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/86.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/35v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/35v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/35v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/36r",
+          "@type": "sc:Canvas",
+          "label": "Folio 36r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/36r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/87.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/87.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/36r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/36r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/36r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/36v",
+          "@type": "sc:Canvas",
+          "label": "Folio 36v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/36v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/88.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/88.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/36v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/36v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/36v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/37r",
+          "@type": "sc:Canvas",
+          "label": "Folio 37r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/37r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/89.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/89.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/37r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/37r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/37r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/37v",
+          "@type": "sc:Canvas",
+          "label": "Folio 37v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/37v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/90.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/90.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/37v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/37v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/37v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/38r",
+          "@type": "sc:Canvas",
+          "label": "Folio 38r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/38r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/91.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/91.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/38r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/38r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/38r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/38v",
+          "@type": "sc:Canvas",
+          "label": "Folio 38v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/38v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/92.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/92.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/38v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/38v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/38v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/39r",
+          "@type": "sc:Canvas",
+          "label": "Folio 39r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/39r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/93.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/93.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/39r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/39r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/39r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/39v",
+          "@type": "sc:Canvas",
+          "label": "Folio 39v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/39v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/94.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/94.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/39v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/39v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/39v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/40r",
+          "@type": "sc:Canvas",
+          "label": "Folio 40r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/40r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/95.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/95.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/40r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/40r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/40r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/40v",
+          "@type": "sc:Canvas",
+          "label": "Folio 40v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/40v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/96.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/96.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/40v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/40v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/40v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/41r",
+          "@type": "sc:Canvas",
+          "label": "Folio 41r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/41r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/97.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/97.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/41r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/41r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/41r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/41v",
+          "@type": "sc:Canvas",
+          "label": "Folio 41v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/41v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/98.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/98.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/41v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/41v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/41v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/42r",
+          "@type": "sc:Canvas",
+          "label": "Folio 42r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/42r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/99.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/99.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/42r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/42r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/42r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/42v",
+          "@type": "sc:Canvas",
+          "label": "Folio 42v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/42v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/100.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/100.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/42v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/42v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/42v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/43r",
+          "@type": "sc:Canvas",
+          "label": "Folio 43r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/43r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/101.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/101.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/43r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/43r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/43r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/43v",
+          "@type": "sc:Canvas",
+          "label": "Folio 43v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/43v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/102.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/102.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/43v"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/43v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/43v.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/44r",
+          "@type": "sc:Canvas",
+          "label": "Folio 44r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/44r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/103.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/103.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/44r"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "http://fauvel.archivengine.com/list/en/44r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fro/44r.json",
+              "@type": "sc:AnnotationList"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/44v",
+          "@type": "sc:Canvas",
+          "label": "Folio 44v",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/44v-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/104.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/104.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/44v"
+            }
+          ]
+        },
+        {
+          "@id": "http://fauvel.archivengine.com/canvas/45r",
+          "@type": "sc:Canvas",
+          "label": "Folio 45r",
+          "height": 7350,
+          "width": 5250,
+          "images": [
+            {
+              "@context": "http://iiif.io/api/presentation/2/context.json",
+              "@id": "http://fauvel.archivengine.com/annotation/45r-image",
+              "resource": {
+                "@id": "https://iip.textlab.org/?IIIF=fauvel/105.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iip.textlab.org/?IIIF=fauvel/105.tiff",
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                },
+                "height": 7350,
+                "width": 5250
+              },
+              "on": "http://fauvel.archivengine.com/canvas/45r"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+
+  ]
 }


### PR DESCRIPTION
### What does the PR do?
Upon Mirador's completion of annotation-loading for a page, the plugin will now render text attached to the annotation on top of its rectangle along with a semi-opaque backdrop for visibility. The text layer menu control now opens into a dropdown allowing the user to switch among no annotations and rendered text in three transcription modes (English, French, original). 

Also adds French and original transcription links to the manifest file.

### What issues does it address?
Closes #9, closes #10, closes #14, closes #39 

### How to test
Open a page in Image View for which there are transcriptions. You should see the hit boxes for the transcription line annotation objects appear briefly, then be replaced by overlaid text. By clicking on the text layer dropdown in the upper right, you should be able to toggle between different languages or turn the text/annotation display off entirely.