### PR TITLE
add missing annotation list links to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -167,11 +167,11 @@
               "@type": "sc:AnnotationList"
             },
             {
-              "@id": "http://fauvel.archivengine.com/list/fr/1r.json",
+              "@id": "http://fauvel.archivengine.com/list/fro/1r.json",
               "@type": "sc:AnnotationList"
             },
             {
-              "@id": "http://fauvel.archivengine.com/list/fro/1r.json",
+              "@id": "http://fauvel.archivengine.com/list/fr/1r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -230,6 +230,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/1v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/1v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -286,6 +290,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/2r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/2r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -344,6 +352,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/2v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/2v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -400,6 +412,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/3r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/3r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -458,6 +474,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/3v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/3v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -514,6 +534,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/4r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/4r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -572,6 +596,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/4v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/4v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -628,6 +656,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/5r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/5r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -686,6 +718,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/5v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/5v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -742,6 +778,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/6r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/6r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -800,6 +840,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/6v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/6v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -856,6 +900,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/7r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/7r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -914,6 +962,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/7v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/7v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -970,6 +1022,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/8r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/8r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1028,6 +1084,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/8v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/8v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1084,6 +1144,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/9r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/9r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1142,6 +1206,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/9v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/9v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1199,6 +1267,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/10r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/10r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1255,6 +1327,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/10v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/10v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1315,6 +1391,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/10v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/10v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1371,6 +1451,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/11v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/11v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1429,6 +1513,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/12r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/12r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1485,6 +1573,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/12v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/12v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1543,6 +1635,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/13r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/13r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1599,6 +1695,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/13v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/13v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1657,6 +1757,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/13r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/13r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1713,6 +1817,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/14v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/14v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1771,6 +1879,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/15r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/15r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1827,6 +1939,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/15v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/15v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1885,6 +2001,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/16r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/16r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -1941,6 +2061,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/16v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/16v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -1999,6 +2123,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/17r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/17r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2055,6 +2183,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/17v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/17v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -2113,6 +2245,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/18r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/18r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2169,6 +2305,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/18v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/18v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -2227,6 +2367,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/19r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/19r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2283,6 +2427,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/19v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/19v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -2341,6 +2489,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/20r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/20r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2397,6 +2549,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/20v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/20v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -2455,6 +2611,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/21r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/21r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2511,6 +2671,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/21v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/21v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -2569,6 +2733,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/22r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/22r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2625,6 +2793,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/22v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/22v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -2683,6 +2855,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/23r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/23r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2739,6 +2915,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/23v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/23v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -2797,6 +2977,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/24r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/24r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2853,6 +3037,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/24v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/24v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -2911,6 +3099,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/25r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/25r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -2967,6 +3159,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/25v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/25v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -3025,6 +3221,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/26r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/26r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3081,6 +3281,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/26v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/26v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -3139,6 +3343,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/27r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/27r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3195,6 +3403,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/27v.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/27v.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -3253,6 +3465,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/28r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/28r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3310,6 +3526,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/28v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/28v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3363,11 +3583,15 @@
           ],
           "otherContent": [
             {
-              "@id": "http://fauvel.archivengine.com/list/en/28bis-r.json",
+              "@id": "http://fauvel.archivengine.com/list/en/28br.json",
               "@type": "sc:AnnotationList"
             },
             {
-              "@id": "http://fauvel.archivengine.com/list/fro/28bis-r.json",
+              "@id": "http://fauvel.archivengine.com/list/fro/28br.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/28br.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -3422,11 +3646,15 @@
           ],
           "otherContent": [
             {
-              "@id": "http://fauvel.archivengine.com/list/en/28bis-v.json",
+              "@id": "http://fauvel.archivengine.com/list/en/28bv.json",
               "@type": "sc:AnnotationList"
             },
             {
-              "@id": "http://fauvel.archivengine.com/list/fro/28bis-v.json",
+              "@id": "http://fauvel.archivengine.com/list/fro/28bv.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/28bv.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -3487,6 +3715,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/28ter-r.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/28ter-r.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3546,6 +3778,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/28ter-v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/28ter-v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3602,6 +3838,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/29r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/29r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -3660,6 +3900,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/29v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/29v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3716,6 +3960,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/30r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/30r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -3774,6 +4022,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/30v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/30v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3830,6 +4082,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/31r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/31r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -3888,6 +4144,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/31v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/31v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -3944,6 +4204,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/32r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/32r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4002,6 +4266,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/32v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/32v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4058,6 +4326,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/33r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/33r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4116,6 +4388,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/33v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/33v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4172,6 +4448,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/34r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/34r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4230,6 +4510,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/34v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/34v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4286,6 +4570,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/35r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/35r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4344,6 +4632,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/35v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/35v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4400,6 +4692,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/36r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/36r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4458,6 +4754,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/36v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/36v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4514,6 +4814,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/37r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/37r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4572,6 +4876,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/37v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/37v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4628,6 +4936,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/38r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/38r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4686,6 +4998,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/38v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/38v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4742,6 +5058,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/39r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/39r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4800,6 +5120,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/39v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/39v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4856,6 +5180,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/40r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/40r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -4914,6 +5242,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/40v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/40v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -4970,6 +5302,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/41r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/41r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -5028,6 +5364,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/41v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/41v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -5084,6 +5424,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/42r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/42r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -5142,6 +5486,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/42v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/42v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -5198,6 +5546,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/43r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/43r.json",
               "@type": "sc:AnnotationList"
             }
           ]
@@ -5256,6 +5608,10 @@
             {
               "@id": "http://fauvel.archivengine.com/list/fro/43v.json",
               "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/43v.json",
+              "@type": "sc:AnnotationList"
             }
           ]
         },
@@ -5312,6 +5668,10 @@
             },
             {
               "@id": "http://fauvel.archivengine.com/list/fro/44r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
+              "@id": "http://fauvel.archivengine.com/list/fr/44r.json",
               "@type": "sc:AnnotationList"
             }
           ]


### PR DESCRIPTION
This PR corrects an omission in #40's addition of annotation list links to the "otherContent" fields in manifest resources; it adds links to the French annotation lists, only the first of which was added on first pass.