### PR TITLE
Fix id collision in search, recompile search index

### DIFF
--- a/js/MiradorTextLayer.js
+++ b/js/MiradorTextLayer.js
@@ -268,7 +268,8 @@ var MiradorTextLayer = {
                   _this.element.find('.search-results-list').empty().show();
                   _this.element.find('.search-results-list').append(self.searchResultSummaryTemplate({ resultsCount: results.length, noResults: results.length === 0, oneResult: results.length === 1 }));
                   results.forEach(function(result) {
-                    var canvasParts = result.ref.split('#');
+                    var canvasString = result.ref.split('|')[0];
+                    var canvasParts = canvasString.split('#');
                     var canvasSubParts = canvasParts[0].split('/');
                     var doc = searchDocs[result.ref];
                     var context = {
@@ -295,13 +296,15 @@ var MiradorTextLayer = {
 
             $.Window.prototype.clearHighlight = function() {
               var _this = this;
-              var items = this.focusModules.ImageView.annotationsLayer.drawTool.annotationsToShapesMap;
-              for (key in items) {
-                items[key].forEach(function(item) {
-                  if (item.data && item.data.bgrect) {
-                    item.data.bgrect.fillColor = _this.backdropColor;
-                  }
-                });
+              if (this.focusModules.ImageView) {
+                var items = this.focusModules.ImageView.annotationsLayer.drawTool.annotationsToShapesMap;
+                for (key in items) {
+                  items[key].forEach(function(item) {
+                    if (item.data && item.data.bgrect) {
+                      item.data.bgrect.fillColor = _this.backdropColor;
+                    }
+                  });
+                }
               }
             }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2975,6 +2975,10 @@
               "@type": "sc:AnnotationList"
             },
             {
+              "@id": "http://fauvel.archivengine.com/list/fr/24r.json",
+              "@type": "sc:AnnotationList"
+            },
+            {
               "@id": "http://fauvel.archivengine.com/list/fro/24r.json",
               "@type": "sc:AnnotationList"
             }

--- a/tools/manifest2lunr
+++ b/tools/manifest2lunr
@@ -32,7 +32,7 @@ def load_transcriptions(canvas_id, annotation_list)
     text = annotation['resource']['chars']
     if !text.empty?
       doc[:t] = text
-      doc[:id] = annotation['on']
+      doc[:id] = annotation['on'] + '|' + annotation['resource']['language'] 
       @store_docs[doc[:id]] = {
         :text => text,
         :language => annotation['resource']['language'],


### PR DESCRIPTION
This PR recompiles the search index to include all annotation lists and adjusts the search result ID format to avoid collisions between different languages on the same canvas area.