### PR TITLE
Adjust zoom on search result focus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ annotation_text_pad: 20
 default_layer: en
 backdrop_color: '#E6D9B7'
 backdrop_opacity: 0.7
+search_zoom_pad: 1000
 
 # Build settings
 markdown: kramdown

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,7 +6,8 @@ layout: default
   data-annotation-text-pad="{{ site.annotation_text_pad }}"
   data-default-layer="{{ site.default_layer }}"
   data-backdrop-color="{{ site.backdrop_color }}"
-  data-backdrop-opacity="{{ site.backdrop_opacity }}">
+  data-backdrop-opacity="{{ site.backdrop_opacity }}"
+  data-search-zoom-pad="{{ site.search_zoom_pad }}">
 </div>
 
 <script type="text/javascript" src="/js/mirador_config.js"></script>

--- a/js/MiradorTextLayer.js
+++ b/js/MiradorTextLayer.js
@@ -106,6 +106,7 @@ var MiradorTextLayer = {
             $.Window.prototype.defaultLayer = jQuery("#viewer").data("default-layer");
             $.Window.prototype.backdropColor = jQuery("#viewer").data("backdrop-color");
             $.Window.prototype.backdropOpacity = jQuery("#viewer").data("backdrop-opacity");
+            $.Window.prototype.searchZoomPad = jQuery("#viewer").data("search-zoom-pad");
 
             $.Window.prototype.listenForActions = function() {
                 var _this = this;
@@ -160,12 +161,13 @@ var MiradorTextLayer = {
                 this.element.on("click", ".mirador-search-result", function(event) {
                   event.stopPropagation();
 
+                  var boundsPad = _this.searchZoomPad;
                   var canvasid = jQuery(this).attr('data-canvasid'),
                       language = jQuery(this).attr('data-language'),
                       annoId = jQuery(this).attr('data-anno-id'),
                       coordinates = jQuery(this).attr('data-coordinates'),
                       xywh = coordinates && coordinates.split('=')[1].split(',').map(Number),
-                      bounds = xywh && {x: xywh[0], y: xywh[1], width: xywh[2], height: xywh[3]};
+                      bounds = xywh && {x: xywh[0] - boundsPad, y: xywh[1] - boundsPad, width: xywh[2] + 2 * boundsPad, height: xywh[3] + 2 * boundsPad};
                   var options = {
                     "canvasID": canvasid,
                     "bounds": bounds


### PR DESCRIPTION
### What does this PR do?
Adds a configuration setting called `search_zoom_pad` that decreases the intensity of the zoom-in when a search result is clicked. Clicking a result will still center the viewer on the corresponding line, but will add the specified amount to each end of the bounds that the viewer zooms to.

### What issues does it address?
Closes #46 

### How to test
Enter a search term and click a result in the list. The viewer should center on the corresponding line, but not zoom in so far that the edges of the line's backdrop line up with the edges of the viewer frame. If you change the `search_zoom_pad` value in _config.yml to a higher value, search result clicks will cause a slighter zoom; if a lower value, a closer zoom.